### PR TITLE
Configure spec task without verbose output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,6 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "standard/rake"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) { |t| t.verbose = false }
 
 task default: %i[standard spec]


### PR DESCRIPTION
As on https://github.com/jonallured/mli/pull/9 this PR turns off the verbose output of RSpec when run via Rake.