### PR TITLE
Run all done commands in the background

### DIFF
--- a/lib/jay/cli/root_command.rb
+++ b/lib/jay/cli/root_command.rb
@@ -6,7 +6,7 @@ module Jay
         basename = `basename $(pwd)`.chomp
         leap_command = "unicornleap --seconds 1"
         say_command = "say #{basename} done -v Daniel"
-        system("#{say_command} & #{leap_command}")
+        system("#{say_command} & #{leap_command} &")
       end
 
       desc "version", "Print the version"


### PR DESCRIPTION
Turns out you can just run both commands in the background by adding another `&` at the end.

## Before

```
jon@shadow-king:~% time jay done
jay done  0.09s user 0.06s system 12% cpu 1.206 total
```

## After

```
jon@shadow-king:~% time jay done
jay done  0.08s user 0.05s system 34% cpu 0.372 total
```

That's better - now control returns seemingly immediately. 