### PR TITLE
Add CHANGELOG commands

### DIFF
--- a/lib/jay.rb
+++ b/lib/jay.rb
@@ -1,3 +1,4 @@
+require "json"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem

--- a/lib/jay/cli/clog_command.rb
+++ b/lib/jay/cli/clog_command.rb
@@ -1,0 +1,40 @@
+module Jay
+  module Cli
+    class ClogCommand < Thor
+      desc "fetch PR_NUMBER", "Fetch and format PR_NUMBER"
+      def fetch(pr_number)
+        command = "gh pr view #{pr_number} --json title,url"
+        result = `#{command}`
+        json = JSON.parse(result)
+        pr_title = json["title"]
+        pr_url = json["url"]
+
+        output = <<~EOF
+          * #{pr_title} ([##{pr_number}][])
+          [##{pr_number}]: #{pr_url}
+        EOF
+
+        say output
+      end
+
+      desc "fresh", "Output fresh section headings"
+      def fresh
+        output = <<~EOF
+          ### Added
+
+          ### Changed
+
+          ### Deprecated
+
+          ### Removed
+
+          ### Fixed
+
+          ### Security
+        EOF
+
+        say output
+      end
+    end
+  end
+end

--- a/lib/jay/cli/root_command.rb
+++ b/lib/jay/cli/root_command.rb
@@ -1,6 +1,9 @@
 module Jay
   module Cli
     class RootCommand < Thor
+      desc "clog", "CHANGELOG commands"
+      subcommand "clog", ClogCommand
+
       desc "done", "Announce when things are done."
       def done
         basename = `basename $(pwd)`.chomp

--- a/spec/fixtures/cli/help.txt
+++ b/spec/fixtures/cli/help.txt
@@ -1,4 +1,5 @@
 Commands:
+  jay clog            # CHANGELOG commands
   jay done            # Announce when things are done.
   jay help [COMMAND]  # Describe available commands or one specific command
   jay version         # Print the version


### PR DESCRIPTION
This PR adds a few new tricks for when I work with CHANGELOG files. One thing that I do a lot with a CHANGELOG is add PRs by copy/pasting the title and URL into a section. This is simplified like so:

```
# print out the markdown for PR #2
$ jay clog fetch 2
* Update executable setup ([#2][])
[#2]: https://github.com/jonallured/jay-clean-history/pull/2

# copy the markdown for PR #2
$ jay clog fetch 2 | pbcopy
```

So now I can do that and then back in vim I can paste in the output and off I go. And then the other command `fresh` will just dump out the CHANGELOG sections so I can reset after a version bump.